### PR TITLE
Proxy false

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -18,7 +18,7 @@ const DB_INTERNAL_URL = process.env;
 config();
 const server = express();
 
-server.set("trust proxy", true);
+server.set("trust proxy", false);
 
 // Configurar el limitador de velocidad: máximo de cinco solicitudes por minuto
 const limiter = RateLimit( {


### PR DESCRIPTION
ValidationError: The Express 'trust proxy' setting is true, which allows anyone to trivially bypass IP-based rate limiting. See https://express-rate-limit.github.io/ERR_ERL_PERMISSIVE_TRUST_PROXY/ for more information.